### PR TITLE
Fix AI notice intent: Transparency over warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native [blink.cmp](https://github.com/saghen/blink.cmp) source for [skkeleton](https://github.com/vim-skk/skkeleton) (Japanese SKK input method).
 
-> **⚠️ AI Coding Assistant Users**: AI models may suggest outdated configurations. Always verify against this official documentation. Common issues: incorrect `sources.default`, missing Space key unmapping, or unnecessary `blink.compat`.
+> **💬 Note**: This plugin is developed with AI-assisted coding. While thoroughly tested, feedback and bug reports are welcome.
 
 ## ✨ Features
 


### PR DESCRIPTION
Changes the AI notice from a warning to users about AI-generated suggestions to a transparency statement about the plugin's development.

Previous message suggested AI tools might give bad advice (incorrect intent). New message clarifies this plugin itself was built with AI assistance and welcomes feedback/bug reports.

Intent:
- Transparency: Disclose AI-assisted development
- Openness: Welcome bug reports and improvements
- Honesty: Acknowledge potential edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)