### PR TITLE
fix: skip empty-label items to avoid frizbee SIMD panic

### DIFF
--- a/lua/blink-cmp-skkeleton/completion.lua
+++ b/lua/blink-cmp-skkeleton/completion.lua
@@ -85,7 +85,14 @@ function M.build_completion_items(candidates, ranks, text_edit_range, filter_tex
       end
 
       local item = M.build_completion_item(kana, word, rank, text_edit_range, filter_text)
-      table.insert(items, item)
+      -- アノテーション専用エントリ (word が ";comment" のような形式) は
+      -- parse_word 後に label が "" になる。空 label を blink.cmp に渡すと
+      -- frizbee の SIMD matcher が空 haystack で panic する
+      -- (saghen/frizbee#64, saghen/frizbee#77 参照)。挿入する文字列も無いので
+      -- 候補として元々無意味であり、ここで弾く。
+      if item.label ~= "" then
+        table.insert(items, item)
+      end
     end
   end
 


### PR DESCRIPTION
## What

`build_completion_items` の中で、`label` が空になった候補を blink.cmp に渡さず除外します。

## Why

SKK 辞書には、アノテーションだけのエントリ (例: 値が `;comment` の形式) が存在します。これは `parse_word` が `;` 以降を全部落とすため、結果の `label` が `""` になります。

空 `label` の候補を blink.cmp に渡すと、blink.cmp の fuzzy matcher である frizbee の SIMD Smith-Waterman 実装が空の haystack に対して

```
could not find max score in score matrix final row
```

で panic します (参照: saghen/frizbee#64、upstream の修正は saghen/frizbee#77)。

frizbee 側が修正済みであっても、空 `label` の候補はそもそも挿入する文字列を持たず、補完候補として無意味です。よって `build_completion_items` の時点で弾くのが、panic 回避と無意味な候補の抑制の両面で妥当だと考えます。

## How

`item.label ~= ""` のときだけ items に追加するようにしました (+8 / -1)。