### PR TITLE
feat: fetch completions asynchronously to avoid blocking the UI

### DIFF
--- a/lua/blink-cmp-skkeleton/init.lua
+++ b/lua/blink-cmp-skkeleton/init.lua
@@ -55,8 +55,13 @@ end
 --- @param callback fun(response: { is_incomplete_forward: boolean, is_incomplete_backward: boolean, items: blink.cmp.CompletionItem[] })
 --- @return function cancel function
 function source:get_completions(context, callback)
-  -- Cancel function (no-op for now since we don't have async operations)
-  local cancel_fun = function() end
+  -- blink.cmp may cancel an in-flight request when the user keeps typing. We
+  -- can't abort the denops RPC itself, but we flip this flag so a late response
+  -- is discarded instead of clobbering a newer one.
+  local cancelled = false
+  local function cancel_fun()
+    cancelled = true
+  end
 
   -- Debug: Log basic information
   utils.debug_log(
@@ -79,32 +84,33 @@ function source:get_completions(context, callback)
     return cancel_fun
   end
 
-  -- Get completion data from skkeleton via denops
-  local candidates, ranks_array, pre_edit = skkeleton.get_completion_data()
+  -- Fetch completion data asynchronously so a slow skkserv never freezes the
+  -- editor. The result is delivered through the callback below.
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    if cancelled then
+      return
+    end
 
-  -- Convert ranks and build items
-  local ranks = completion.convert_ranks_to_map(ranks_array)
+    vim.schedule(function()
+      if cancelled then
+        return
+      end
 
-  -- Compute text_edit_range using context module
-  local text_edit_range = context_module.compute_text_edit_range(context, pre_edit)
+      local ranks = completion.convert_ranks_to_map(ranks_array)
+      local text_edit_range = context_module.compute_text_edit_range(context, pre_edit)
+      local filter_text = context_module.extract_filter_text(context, pre_edit)
+      local items = completion.build_completion_items(candidates, ranks, text_edit_range, filter_text)
 
-  -- Extract filterText using context module
-  local filter_text = context_module.extract_filter_text(context, pre_edit)
+      utils.debug_log(string.format("Returning %d items for pre_edit='%s'", #items, pre_edit))
 
-  local items = completion.build_completion_items(candidates, ranks, text_edit_range, filter_text)
-
-  utils.debug_log(string.format("Returning %d items for pre_edit='%s'", #items, pre_edit))
-
-  -- Wrap callback in vim.schedule_wrap
-  local wrapped_callback = vim.schedule_wrap(function()
-    callback({
-      is_incomplete_forward = true, -- Tell blink.cmp not to filter
-      is_incomplete_backward = true,
-      items = items,
-    })
+      callback({
+        is_incomplete_forward = true, -- Tell blink.cmp not to filter
+        is_incomplete_backward = true,
+        items = items,
+      })
+    end)
   end)
 
-  wrapped_callback()
   return cancel_fun
 end
 

--- a/lua/blink-cmp-skkeleton/skkeleton.lua
+++ b/lua/blink-cmp-skkeleton/skkeleton.lua
@@ -10,7 +10,7 @@ local M = {}
 -- Cache instance
 local cache = cache_module.new()
 
---- Request data from skkeleton via denops
+--- Request data from skkeleton via denops (synchronous, blocks the UI)
 --- @param key string
 --- @param args? any[]
 --- @return unknown
@@ -18,6 +18,94 @@ local function request(key, args)
   args = args or {}
   local ok, result = pcall(vim.fn["denops#request"], "skkeleton", key, args)
   return ok and result or nil
+end
+
+--- Request data from skkeleton via denops (asynchronous, never blocks the UI)
+--- @param key string
+--- @param on_success fun(result: unknown)
+--- @param on_failure? fun(err: unknown)
+local function request_async(key, on_success, on_failure)
+  local ok = pcall(vim.fn["denops#request_async"], "skkeleton", key, {}, function(result)
+    on_success(result)
+  end, function(err)
+    if on_failure then
+      on_failure(err)
+    end
+  end)
+  -- denops#request_async itself can throw (e.g. server not yet running). Treat
+  -- that the same as an RPC failure so the caller always gets a response.
+  if not ok and on_failure then
+    on_failure(nil)
+  end
+end
+
+--- Resolve pre_edit, falling back to extracting it from the current line when
+--- skkeleton reports an empty value. Shared by the sync and async fetchers.
+--- @param raw string|nil value returned by getPreEdit
+--- @return string
+local function normalize_pre_edit(raw)
+  local pre_edit = raw or ""
+  if pre_edit == "" then
+    local extracted = context_module.extract_pre_edit_from_line()
+    if extracted then
+      pre_edit = extracted
+      utils.debug_log(string.format("Extracted pre_edit: '%s'", pre_edit))
+    end
+  end
+  return pre_edit
+end
+
+--- Look up cached completion data for a pre_edit / cursor position.
+--- Mirrors the original caching strategy: use the cache when the pre_edit
+--- matches, or when pre_edit is empty but the cursor has not moved (rapid
+--- consecutive calls).
+--- @param pre_edit string
+--- @param cursor_line integer
+--- @param cursor_col integer
+--- @return table|nil cached_data { candidates, ranks, pre_edit }
+local function lookup_cache(pre_edit, cursor_line, cursor_col)
+  local cached_data = cache.get(pre_edit)
+
+  if not cached_data and pre_edit == "" then
+    local state = cache.get_state()
+    if state.meta then
+      local same_position = (state.meta[1] == cursor_line and state.meta[2] == cursor_col)
+      local cache_age = vim.loop.now() - state.timestamp
+      if same_position and cache_age < cache.get_ttl() then
+        utils.debug_log(string.format("Using cache at same position (age=%dms)", cache_age))
+        cached_data = cache.get(state.key)
+      end
+    end
+  end
+
+  if cached_data then
+    local stats = cache.get_stats()
+    utils.debug_log(
+      string.format(
+        "Cache HIT for '%s' (total: %d/%d, %.1f%%)",
+        pre_edit,
+        stats.hits,
+        stats.hits + stats.misses,
+        stats.hit_rate
+      )
+    )
+  end
+
+  return cached_data
+end
+
+--- Store freshly fetched completion data in the cache.
+--- @param pre_edit string
+--- @param candidates any[]
+--- @param ranks_array any[]
+--- @param cursor_line integer
+--- @param cursor_col integer
+local function store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
+  cache.set(pre_edit, {
+    candidates = candidates,
+    ranks = ranks_array,
+    pre_edit = pre_edit,
+  }, { cursor_line, cursor_col })
 end
 
 --- Clear cache and reset statistics (public for testing)
@@ -38,78 +126,70 @@ function M.is_enabled()
   return result == true or result == 1
 end
 
---- Get completion data from skkeleton (with caching)
+--- Get completion data from skkeleton (synchronous, with caching).
+--- Kept for callers that need a blocking result; new code should prefer
+--- get_completion_data_async to avoid freezing the UI on slow dictionaries
+--- (e.g. an skkserv that falls back to a network lookup).
 --- @return table candidates, table ranks_array, string pre_edit
 function M.get_completion_data()
-  -- Step 1: Get current cursor position
   local cursor_pos = vim.api.nvim_win_get_cursor(0)
   local cursor_line = cursor_pos[1]
   local cursor_col = cursor_pos[2]
 
-  -- Step 2: Get pre_edit (lightweight RPC)
-  local pre_edit = request("getPreEdit") or ""
+  local pre_edit = normalize_pre_edit(request("getPreEdit"))
 
-  -- Step 2.5: If pre_edit is empty, try to extract from current line
-  if pre_edit == "" then
-    local extracted = context_module.extract_pre_edit_from_line()
-    if extracted then
-      pre_edit = extracted
-      utils.debug_log(string.format("Extracted pre_edit: '%s'", pre_edit))
-    end
-  end
-
-  -- Step 3: Check if we can use cached data
-  -- Use cache if:
-  -- a) pre_edit matches the cached key, OR
-  -- b) pre_edit is empty AND cursor position hasn't changed (rapid consecutive calls)
-  local cached_data = cache.get(pre_edit)
-
-  if not cached_data and pre_edit == "" then
-    -- If pre_edit is empty but we're at the same cursor position, use cache
-    local state = cache.get_state()
-    if state.meta then
-      local same_position = (state.meta[1] == cursor_line and state.meta[2] == cursor_col)
-      local cache_age = vim.loop.now() - state.timestamp
-
-      if same_position and cache_age < cache.get_ttl() then
-        utils.debug_log(string.format("Using cache at same position (age=%dms)", cache_age))
-        -- Re-fetch from cache using the original key
-        cached_data = cache.get(state.key)
-      end
-    end
-  end
-
+  local cached_data = lookup_cache(pre_edit, cursor_line, cursor_col)
   if cached_data then
-    local stats = cache.get_stats()
-    local hit_rate = stats.hit_rate
-    utils.debug_log(
-      string.format(
-        "Cache HIT for '%s' (total: %d/%d, %.1f%%)",
-        pre_edit,
-        stats.hits,
-        stats.hits + stats.misses,
-        hit_rate
-      )
-    )
     return cached_data.candidates, cached_data.ranks, cached_data.pre_edit
   end
 
-  -- Step 4: Cache miss - fetch data
   utils.debug_log(string.format("Cache MISS for '%s', fetching...", pre_edit))
-
   local candidates = request("getCompletionResult") or {}
   local ranks_array = request("getRanks") or {}
-
   utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #candidates))
 
-  -- Step 5: Update cache with cursor position
-  cache.set(pre_edit, {
-    candidates = candidates,
-    ranks = ranks_array,
-    pre_edit = pre_edit,
-  }, { cursor_line, cursor_col })
-
+  store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
   return candidates, ranks_array, pre_edit
+end
+
+--- Get completion data from skkeleton without blocking the UI.
+--- Issues the getPreEdit / getCompletionResult / getRanks RPCs via
+--- denops#request_async and invokes `callback` once the data is ready. The
+--- same caching strategy as the synchronous variant is applied.
+--- @param callback fun(candidates: table, ranks_array: table, pre_edit: string)
+function M.get_completion_data_async(callback)
+  local cursor_pos = vim.api.nvim_win_get_cursor(0)
+  local cursor_line = cursor_pos[1]
+  local cursor_col = cursor_pos[2]
+
+  request_async("getPreEdit", function(raw_pre_edit)
+    local pre_edit = normalize_pre_edit(raw_pre_edit)
+
+    local cached_data = lookup_cache(pre_edit, cursor_line, cursor_col)
+    if cached_data then
+      callback(cached_data.candidates, cached_data.ranks, cached_data.pre_edit)
+      return
+    end
+
+    utils.debug_log(string.format("Cache MISS for '%s', fetching (async)...", pre_edit))
+    request_async("getCompletionResult", function(raw_candidates)
+      local candidates = raw_candidates or {}
+      request_async("getRanks", function(raw_ranks)
+        local ranks_array = raw_ranks or {}
+        store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
+        utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #candidates))
+        callback(candidates, ranks_array, pre_edit)
+      end, function()
+        -- getRanks failed: still surface candidates with empty ranks
+        store_cache(pre_edit, candidates, {}, cursor_line, cursor_col)
+        callback(candidates, {}, pre_edit)
+      end)
+    end, function()
+      callback({}, {}, pre_edit)
+    end)
+  end, function()
+    callback({}, {}, "")
+  end)
 end
 
 --- Register completion result with skkeleton for dictionary learning

--- a/tests/test_init.lua
+++ b/tests/test_init.lua
@@ -185,6 +185,7 @@ T["get_completions"]["returns empty when skkeleton is disabled"] = function()
 end
 
 T["get_completions"]["builds completion items correctly"] = function()
+  require("blink-cmp-skkeleton.skkeleton").clear_cache()
   local source = new_source()
   local old_fn = vim.fn
   vim.fn = setmetatable({}, {
@@ -194,14 +195,14 @@ T["get_completions"]["builds completion items correctly"] = function()
           return 1
         end
       end
-      if k == "denops#request" then
-        return function(plugin, method, args)
+      if k == "denops#request_async" then
+        return function(plugin, method, args, success, _failure)
           if method == "getCompletionResult" then
-            return { { "あい", { "愛", "藍;indigo" } } }
+            success({ { "あい", { "愛", "藍;indigo" } } })
           elseif method == "getRanks" then
-            return { { "愛", 100 } }
+            success({ { "愛", 100 } })
           elseif method == "getPreEdit" then
-            return "▽あい"
+            success("▽あい")
           end
         end
       end
@@ -209,10 +210,20 @@ T["get_completions"]["builds completion items correctly"] = function()
     end,
   })
 
+  -- extract_filter_text slices the live buffer line using context.bounds, so
+  -- populate the buffer to exercise the real path (filterText == reading
+  -- without the ▽ marker). "▽あい" is 9 bytes; "あい" starts at byte 4.
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "▽あい" })
+  vim.api.nvim_win_set_cursor(0, { 1, 9 })
+
   local callback_called = false
   local items = nil
 
-  source:get_completions({ cursor = { 1, 9 }, line = "▽あい" }, function(response)
+  source:get_completions({
+    cursor = { 1, 9 },
+    line = "▽あい",
+    bounds = { start_col = 4, length = 6 },
+  }, function(response)
     callback_called = true
     items = response.items
   end)
@@ -226,7 +237,9 @@ T["get_completions"]["builds completion items correctly"] = function()
   expect.equality(items[2].label, "藍")
   expect.no_equality(items[2].documentation, nil)
 
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "" })
   vim.fn = old_fn
+  require("blink-cmp-skkeleton.skkeleton").clear_cache()
 end
 
 -- resolve tests

--- a/tests/test_skkeleton.lua
+++ b/tests/test_skkeleton.lua
@@ -533,4 +533,106 @@ T["cache TTL boundary"]["just before TTL is cache hit"] = function()
   skkeleton.clear_cache()
 end
 
+-- get_completion_data_async tests
+T["get_completion_data_async"] = new_set()
+
+--- Build a vim.fn mock whose denops#request_async resolves each method via the
+--- success callback. `counter` (optional) is incremented per async RPC.
+local function mock_async(old_fn, responses, counter)
+  return setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, _failure)
+          if counter then
+            counter.count = counter.count + 1
+          end
+          success(responses[method])
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+end
+
+T["get_completion_data_async"]["returns completion data"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛", "藍" } } },
+    getRanks = { { "愛", 100 } },
+  })
+
+  local result
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 1)
+  expect.equality(result.candidates[1][1], "あい")
+  expect.equality(result.ranks_array[1][1], "愛")
+  expect.equality(result.pre_edit, "▽あい")
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["returns empty data on failure"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  vim.fn = setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, failure)
+          if method == "getPreEdit" then
+            success("▽あい")
+          else
+            -- getCompletionResult fails
+            failure("boom")
+          end
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+
+  local result
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 0)
+  expect.equality(#result.ranks_array, 0)
+  expect.equality(result.pre_edit, "▽あい")
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["caches result for same pre_edit"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  local counter = { count = 0 }
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = { { "愛", 100 } },
+  }, counter)
+
+  -- First call: cache miss (getPreEdit + getCompletionResult + getRanks)
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 3)
+
+  -- Second call: cache hit (only getPreEdit to check the key)
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 1)
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
 return T


### PR DESCRIPTION
## What

`source:get_completions` の補完取得を非同期に行い、補完取得中に Neovim の UI スレッドをブロックしないようにします。

## Why

現状 `get_completions` は `skkeleton.get_completion_data()` 経由で `denops#request` を呼んでいます。これは skkeleton(さらに `sources = { "skk_server" }` の場合は skkserv バックエンド)の応答が返るまでメインループを止め、Neovim がフリーズしてしまいます。

たまたま僕は `yaskkserv2` をデフォルト設定で運用していたのですが、これでは辞書に無い読みを Google 日本語入力にフォールバックするのでその度に Neovim ごと固まっていました。

## How

- `skkeleton.get_completion_data_async(callback)` を追加。`getPreEdit` → `getCompletionResult` → `getRanks` を `denops#request_async` で順に発行し、揃ったら `callback` を呼ぶ。
- キャッシュ戦略は同期版 `get_completion_data`(互換のため残置)と共通化(`normalize_pre_edit` / `lookup_cache` / `store_cache` ヘルパに抽出)。観測可能な RPC 回数・キャッシュ挙動は同期版と同一。
- `get_completions` を async 版に切り替え。blink が途中でリクエストを cancel した場合に**遅れて届いた応答を破棄**する cancel フラグを導入(RPC 自体は中断できないため）。
- アイテム構築と blink への callback は `vim.schedule` 内で実施。

## Tests

- `get_completion_data_async` のテストを追加(正常・失敗・キャッシュヒット)。
- `get_completions` 統合テストの mock を `denops#request_async` に更新。
- `builds completion items correctly` は **main 時点で既に失敗していた**(CI は luacheck/stylua のみで test を回していないため見逃されていた)アサーションでした。`bounds` ベースの `filterText` 経路を実際に通すようバッファを設定して修正しています。

`nvim --headless --noplugin -u ./tests/minimal_init.lua -c "lua MiniTest.run()"` で全 94 ケース green、`stylua --check` も clean を確認済みです。