### PR TITLE
UI が止まらないよう非同期に補完する

### DIFF
--- a/lua/blink-cmp-skkeleton/init.lua
+++ b/lua/blink-cmp-skkeleton/init.lua
@@ -85,7 +85,9 @@ function source:get_completions(context, callback)
   end
 
   -- Fetch completion data asynchronously so a slow skkserv never freezes the
-  -- editor. The result is delivered through the callback below.
+  -- editor. The result is delivered through the callback below. The
+  -- `should_cancel` predicate lets the RPC chain abort early (and skip caching)
+  -- once blink.cmp has superseded this request.
   skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
     if cancelled then
       return
@@ -109,6 +111,8 @@ function source:get_completions(context, callback)
         items = items,
       })
     end)
+  end, function()
+    return cancelled
   end)
 
   return cancel_fun

--- a/lua/blink-cmp-skkeleton/init.lua
+++ b/lua/blink-cmp-skkeleton/init.lua
@@ -55,8 +55,13 @@ end
 --- @param callback fun(response: { is_incomplete_forward: boolean, is_incomplete_backward: boolean, items: blink.cmp.CompletionItem[] })
 --- @return function cancel function
 function source:get_completions(context, callback)
-  -- Cancel function (no-op for now since we don't have async operations)
-  local cancel_fun = function() end
+  -- blink.cmp may cancel an in-flight request when the user keeps typing. We
+  -- can't abort the denops RPC itself, but we flip this flag so a late response
+  -- is discarded instead of clobbering a newer one.
+  local cancelled = false
+  local function cancel_fun()
+    cancelled = true
+  end
 
   -- Debug: Log basic information
   utils.debug_log(
@@ -79,32 +84,33 @@ function source:get_completions(context, callback)
     return cancel_fun
   end
 
-  -- Get completion data from skkeleton via denops
-  local candidates, ranks_array, pre_edit = skkeleton.get_completion_data()
+  -- Fetch completion data asynchronously so a slow skkserv never freezes the
+  -- editor. The result is delivered through the callback below.
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    if cancelled then
+      return
+    end
 
-  -- Convert ranks and build items
-  local ranks = completion.convert_ranks_to_map(ranks_array)
+    vim.schedule(function()
+      if cancelled then
+        return
+      end
 
-  -- Compute text_edit_range using context module
-  local text_edit_range = context_module.compute_text_edit_range(context, pre_edit)
+      local ranks = completion.convert_ranks_to_map(ranks_array)
+      local text_edit_range = context_module.compute_text_edit_range(context, pre_edit)
+      local filter_text = context_module.extract_filter_text(context, pre_edit)
+      local items = completion.build_completion_items(candidates, ranks, text_edit_range, filter_text)
 
-  -- Extract filterText using context module
-  local filter_text = context_module.extract_filter_text(context, pre_edit)
+      utils.debug_log(string.format("Returning %d items for pre_edit='%s'", #items, pre_edit))
 
-  local items = completion.build_completion_items(candidates, ranks, text_edit_range, filter_text)
-
-  utils.debug_log(string.format("Returning %d items for pre_edit='%s'", #items, pre_edit))
-
-  -- Wrap callback in vim.schedule_wrap
-  local wrapped_callback = vim.schedule_wrap(function()
-    callback({
-      is_incomplete_forward = true, -- Tell blink.cmp not to filter
-      is_incomplete_backward = true,
-      items = items,
-    })
+      callback({
+        is_incomplete_forward = true, -- Tell blink.cmp not to filter
+        is_incomplete_backward = true,
+        items = items,
+      })
+    end)
   end)
 
-  wrapped_callback()
   return cancel_fun
 end
 

--- a/lua/blink-cmp-skkeleton/skkeleton.lua
+++ b/lua/blink-cmp-skkeleton/skkeleton.lua
@@ -94,6 +94,28 @@ local function lookup_cache(pre_edit, cursor_line, cursor_col)
   return cached_data
 end
 
+--- Drop candidates whose midashi (kana) does not start with `prefix`.
+--- skkserv completion ("1<prefix> ") only ever returns midashis that begin with
+--- the prefix, so a candidate that fails this check came from a stale skkeleton
+--- state and must not be shown. UTF-8 byte-prefix matching coincides with
+--- character-prefix matching, so a plain `sub` comparison is correct.
+--- @param candidates any[]
+--- @param prefix string
+--- @return any[]
+local function filter_candidates_by_prefix(candidates, prefix)
+  if prefix == "" then
+    return candidates
+  end
+  local filtered = {}
+  for _, cand in ipairs(candidates) do
+    local kana = cand[1]
+    if type(kana) == "string" and kana:sub(1, #prefix) == prefix then
+      table.insert(filtered, cand)
+    end
+  end
+  return filtered
+end
+
 --- Store freshly fetched completion data in the cache.
 --- @param pre_edit string
 --- @param candidates any[]
@@ -153,39 +175,91 @@ function M.get_completion_data()
 end
 
 --- Get completion data from skkeleton without blocking the UI.
---- Issues the getPreEdit / getCompletionResult / getRanks RPCs via
---- denops#request_async and invokes `callback` once the data is ready. The
---- same caching strategy as the synchronous variant is applied.
+---
+--- Because the RPCs are no longer atomic (the user can keep typing between each
+--- async round-trip), the reading and the candidates could otherwise be read
+--- from different skkeleton states and end up mismatched. Two guards keep them
+--- consistent: getPrefix (= state.henkanFeed, the exact key candidates are
+--- generated from) is read first, and candidates whose midashi does not start
+--- with that prefix are dropped, so candidates from an unrelated reading never
+--- surface. An empty prefix means skkeleton is not in input state, so we return
+--- empty instead of falling back to the buffer. A `should_cancel` predicate lets
+--- a superseded request bail out without polluting the (single-slot) cache.
 --- @param callback fun(candidates: table, ranks_array: table, pre_edit: string)
-function M.get_completion_data_async(callback)
+--- @param should_cancel? fun(): boolean returns true when the request is stale
+function M.get_completion_data_async(callback, should_cancel)
+  should_cancel = should_cancel or function()
+    return false
+  end
+
   local cursor_pos = vim.api.nvim_win_get_cursor(0)
   local cursor_line = cursor_pos[1]
   local cursor_col = cursor_pos[2]
 
-  request_async("getPreEdit", function(raw_pre_edit)
-    local pre_edit = normalize_pre_edit(raw_pre_edit)
+  -- Deliver an empty result without touching the cache.
+  local function bail()
+    callback({}, {}, "")
+  end
 
-    local cached_data = lookup_cache(pre_edit, cursor_line, cursor_col)
-    if cached_data then
-      callback(cached_data.candidates, cached_data.ranks, cached_data.pre_edit)
-      return
+  if should_cancel() then
+    return bail()
+  end
+
+  request_async("getPrefix", function(raw_prefix)
+    local prefix = raw_prefix or ""
+    -- Empty prefix means skkeleton is not in input state, so there can be no
+    -- candidates. Return empty instead of falling back to extracting pre_edit
+    -- from the buffer, which would mix a buffer-derived reading with live-state
+    -- candidates.
+    if prefix == "" or should_cancel() then
+      return bail()
     end
 
-    utils.debug_log(string.format("Cache MISS for '%s', fetching (async)...", pre_edit))
-    request_async("getCompletionResult", function(raw_candidates)
-      local candidates = raw_candidates or {}
-      request_async("getRanks", function(raw_ranks)
-        local ranks_array = raw_ranks or {}
-        store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
-        utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #candidates))
-        callback(candidates, ranks_array, pre_edit)
+    request_async("getPreEdit", function(raw_pre_edit)
+      if should_cancel() then
+        return bail()
+      end
+      -- Use the raw pre_edit (no buffer fallback): with a non-empty prefix,
+      -- toString() is guaranteed non-empty ("▽…").
+      local pre_edit = raw_pre_edit or ""
+
+      local cached_data = lookup_cache(pre_edit, cursor_line, cursor_col)
+      if cached_data then
+        callback(cached_data.candidates, cached_data.ranks, cached_data.pre_edit)
+        return
+      end
+
+      -- Filter against the prefix, then store and deliver the result.
+      local function finalize(candidates, ranks_array)
+        local filtered = filter_candidates_by_prefix(candidates, prefix)
+        store_cache(pre_edit, filtered, ranks_array, cursor_line, cursor_col)
+        utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #filtered))
+        callback(filtered, ranks_array, pre_edit)
+      end
+
+      utils.debug_log(string.format("Cache MISS for '%s', fetching (async)...", pre_edit))
+      request_async("getCompletionResult", function(raw_candidates)
+        if should_cancel() then
+          return bail()
+        end
+        local candidates = raw_candidates or {}
+        request_async("getRanks", function(raw_ranks)
+          if should_cancel() then
+            return bail()
+          end
+          finalize(candidates, raw_ranks or {})
+        end, function()
+          -- getRanks failed: still surface candidates with empty ranks.
+          if should_cancel() then
+            return bail()
+          end
+          finalize(candidates, {})
+        end)
       end, function()
-        -- getRanks failed: still surface candidates with empty ranks
-        store_cache(pre_edit, candidates, {}, cursor_line, cursor_col)
-        callback(candidates, {}, pre_edit)
+        callback({}, {}, pre_edit)
       end)
     end, function()
-      callback({}, {}, pre_edit)
+      callback({}, {}, "")
     end)
   end, function()
     callback({}, {}, "")

--- a/lua/blink-cmp-skkeleton/skkeleton.lua
+++ b/lua/blink-cmp-skkeleton/skkeleton.lua
@@ -178,13 +178,25 @@ end
 ---
 --- Because the RPCs are no longer atomic (the user can keep typing between each
 --- async round-trip), the reading and the candidates could otherwise be read
---- from different skkeleton states and end up mismatched. Two guards keep them
---- consistent: getPrefix (= state.henkanFeed, the exact key candidates are
---- generated from) is read first, and candidates whose midashi does not start
---- with that prefix are dropped, so candidates from an unrelated reading never
---- surface. An empty prefix means skkeleton is not in input state, so we return
---- empty instead of falling back to the buffer. A `should_cancel` predicate lets
---- a superseded request bail out without polluting the (single-slot) cache.
+--- from different skkeleton states and end up mismatched. Three guards keep them
+--- consistent:
+---  1. getPrefix (= state.henkanFeed, the exact key candidates are generated
+---     from) is read first, and candidates whose midashi does not start with
+---     that prefix are dropped, so candidates from an unrelated reading never
+---     surface.
+---  2. getPrefix is read AGAIN after the candidates and ranks have been
+---     fetched. If state.henkanFeed changed at any point during the fetch, the
+---     reading (getPreEdit), candidates and ranks may each have been read from a
+---     different state -- the whole result is discarded. This is what stops the
+---     candidate/reading mismatch the per-candidate filter cannot: the filter
+---     only ties candidates to the prefix, not the prefix to the displayed
+---     pre_edit, so without this bracket a keystroke landing between getPrefix
+---     and getPreEdit would surface (filter-passing) candidates under an
+---     unrelated reading.
+---  3. An empty prefix means skkeleton is not in input state, so we return empty
+---     instead of falling back to the buffer.
+--- A `should_cancel` predicate lets a superseded request bail out without
+--- polluting the (single-slot) cache.
 --- @param callback fun(candidates: table, ranks_array: table, pre_edit: string)
 --- @param should_cancel? fun(): boolean returns true when the request is stale
 function M.get_completion_data_async(callback, should_cancel)
@@ -229,12 +241,27 @@ function M.get_completion_data_async(callback, should_cancel)
         return
       end
 
-      -- Filter against the prefix, then store and deliver the result.
+      -- Re-read the prefix once everything has been fetched. If it no longer
+      -- matches the prefix we started from, skkeleton's henkanFeed changed
+      -- mid-fetch, so pre_edit / candidates / ranks may be from different states
+      -- and must not be shown together. Only on a stable prefix do we filter,
+      -- cache and deliver.
       local function finalize(candidates, ranks_array)
-        local filtered = filter_candidates_by_prefix(candidates, prefix)
-        store_cache(pre_edit, filtered, ranks_array, cursor_line, cursor_col)
-        utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #filtered))
-        callback(filtered, ranks_array, pre_edit)
+        request_async("getPrefix", function(raw_prefix2)
+          if should_cancel() then
+            return bail()
+          end
+          if (raw_prefix2 or "") ~= prefix then
+            utils.debug_log(
+              string.format("Prefix changed mid-fetch ('%s' -> '%s'), discarding", prefix, raw_prefix2 or "")
+            )
+            return bail()
+          end
+          local filtered = filter_candidates_by_prefix(candidates, prefix)
+          store_cache(pre_edit, filtered, ranks_array, cursor_line, cursor_col)
+          utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #filtered))
+          callback(filtered, ranks_array, pre_edit)
+        end, bail)
       end
 
       utils.debug_log(string.format("Cache MISS for '%s', fetching (async)...", pre_edit))

--- a/lua/blink-cmp-skkeleton/skkeleton.lua
+++ b/lua/blink-cmp-skkeleton/skkeleton.lua
@@ -3,7 +3,6 @@
 
 local utils = require("blink-cmp-skkeleton.utils")
 local cache_module = require("blink-cmp-skkeleton.cache")
-local context_module = require("blink-cmp-skkeleton.context")
 
 local M = {}
 
@@ -37,22 +36,6 @@ local function request_async(key, on_success, on_failure)
   if not ok and on_failure then
     on_failure(nil)
   end
-end
-
---- Resolve pre_edit, falling back to extracting it from the current line when
---- skkeleton reports an empty value. Shared by the sync and async fetchers.
---- @param raw string|nil value returned by getPreEdit
---- @return string
-local function normalize_pre_edit(raw)
-  local pre_edit = raw or ""
-  if pre_edit == "" then
-    local extracted = context_module.extract_pre_edit_from_line()
-    if extracted then
-      pre_edit = extracted
-      utils.debug_log(string.format("Extracted pre_edit: '%s'", pre_edit))
-    end
-  end
-  return pre_edit
 end
 
 --- Look up cached completion data for a pre_edit / cursor position.
@@ -146,32 +129,6 @@ end
 function M.is_enabled()
   local result = utils.safe_call(vim.fn["skkeleton#is_enabled"])
   return result == true or result == 1
-end
-
---- Get completion data from skkeleton (synchronous, with caching).
---- Kept for callers that need a blocking result; new code should prefer
---- get_completion_data_async to avoid freezing the UI on slow dictionaries
---- (e.g. an skkserv that falls back to a network lookup).
---- @return table candidates, table ranks_array, string pre_edit
-function M.get_completion_data()
-  local cursor_pos = vim.api.nvim_win_get_cursor(0)
-  local cursor_line = cursor_pos[1]
-  local cursor_col = cursor_pos[2]
-
-  local pre_edit = normalize_pre_edit(request("getPreEdit"))
-
-  local cached_data = lookup_cache(pre_edit, cursor_line, cursor_col)
-  if cached_data then
-    return cached_data.candidates, cached_data.ranks, cached_data.pre_edit
-  end
-
-  utils.debug_log(string.format("Cache MISS for '%s', fetching...", pre_edit))
-  local candidates = request("getCompletionResult") or {}
-  local ranks_array = request("getRanks") or {}
-  utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #candidates))
-
-  store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
-  return candidates, ranks_array, pre_edit
 end
 
 --- Get completion data from skkeleton without blocking the UI.

--- a/lua/blink-cmp-skkeleton/skkeleton.lua
+++ b/lua/blink-cmp-skkeleton/skkeleton.lua
@@ -10,7 +10,7 @@ local M = {}
 -- Cache instance
 local cache = cache_module.new()
 
---- Request data from skkeleton via denops
+--- Request data from skkeleton via denops (synchronous, blocks the UI)
 --- @param key string
 --- @param args? any[]
 --- @return unknown
@@ -18,6 +18,94 @@ local function request(key, args)
   args = args or {}
   local ok, result = pcall(vim.fn["denops#request"], "skkeleton", key, args)
   return ok and result or nil
+end
+
+--- Request data from skkeleton via denops (asynchronous, never blocks the UI)
+--- @param key string
+--- @param on_success fun(result: unknown)
+--- @param on_failure? fun(err: unknown)
+local function request_async(key, on_success, on_failure)
+  local ok = pcall(vim.fn["denops#request_async"], "skkeleton", key, {}, function(result)
+    on_success(result)
+  end, function(err)
+    if on_failure then
+      on_failure(err)
+    end
+  end)
+  -- denops#request_async itself can throw (e.g. server not yet running). Treat
+  -- that the same as an RPC failure so the caller always gets a response.
+  if not ok and on_failure then
+    on_failure(nil)
+  end
+end
+
+--- Resolve pre_edit, falling back to extracting it from the current line when
+--- skkeleton reports an empty value. Shared by the sync and async fetchers.
+--- @param raw string|nil value returned by getPreEdit
+--- @return string
+local function normalize_pre_edit(raw)
+  local pre_edit = raw or ""
+  if pre_edit == "" then
+    local extracted = context_module.extract_pre_edit_from_line()
+    if extracted then
+      pre_edit = extracted
+      utils.debug_log(string.format("Extracted pre_edit: '%s'", pre_edit))
+    end
+  end
+  return pre_edit
+end
+
+--- Look up cached completion data for a pre_edit / cursor position.
+--- Mirrors the original caching strategy: use the cache when the pre_edit
+--- matches, or when pre_edit is empty but the cursor has not moved (rapid
+--- consecutive calls).
+--- @param pre_edit string
+--- @param cursor_line integer
+--- @param cursor_col integer
+--- @return table|nil cached_data { candidates, ranks, pre_edit }
+local function lookup_cache(pre_edit, cursor_line, cursor_col)
+  local cached_data = cache.get(pre_edit)
+
+  if not cached_data and pre_edit == "" then
+    local state = cache.get_state()
+    if state.meta then
+      local same_position = (state.meta[1] == cursor_line and state.meta[2] == cursor_col)
+      local cache_age = vim.loop.now() - state.timestamp
+      if same_position and cache_age < cache.get_ttl() then
+        utils.debug_log(string.format("Using cache at same position (age=%dms)", cache_age))
+        cached_data = cache.get(state.key)
+      end
+    end
+  end
+
+  if cached_data then
+    local stats = cache.get_stats()
+    utils.debug_log(
+      string.format(
+        "Cache HIT for '%s' (total: %d/%d, %.1f%%)",
+        pre_edit,
+        stats.hits,
+        stats.hits + stats.misses,
+        stats.hit_rate
+      )
+    )
+  end
+
+  return cached_data
+end
+
+--- Store freshly fetched completion data in the cache.
+--- @param pre_edit string
+--- @param candidates any[]
+--- @param ranks_array any[]
+--- @param cursor_line integer
+--- @param cursor_col integer
+local function store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
+  cache.set(pre_edit, {
+    candidates = candidates,
+    ranks = ranks_array,
+    pre_edit = pre_edit,
+  }, { cursor_line, cursor_col })
 end
 
 --- Clear cache and reset statistics (public for testing)
@@ -38,78 +126,70 @@ function M.is_enabled()
   return result == true or result == 1
 end
 
---- Get completion data from skkeleton (with caching)
+--- Get completion data from skkeleton (synchronous, with caching).
+--- Kept for callers that need a blocking result; new code should prefer
+--- get_completion_data_async to avoid freezing the UI on slow dictionaries
+--- (e.g. an skkserv that falls back to a network lookup).
 --- @return table candidates, table ranks_array, string pre_edit
 function M.get_completion_data()
-  -- Step 1: Get current cursor position
   local cursor_pos = vim.api.nvim_win_get_cursor(0)
   local cursor_line = cursor_pos[1]
   local cursor_col = cursor_pos[2]
 
-  -- Step 2: Get pre_edit (lightweight RPC)
-  local pre_edit = request("getPreEdit") or ""
+  local pre_edit = normalize_pre_edit(request("getPreEdit"))
 
-  -- Step 2.5: If pre_edit is empty, try to extract from current line
-  if pre_edit == "" then
-    local extracted = context_module.extract_pre_edit_from_line()
-    if extracted then
-      pre_edit = extracted
-      utils.debug_log(string.format("Extracted pre_edit: '%s'", pre_edit))
-    end
-  end
-
-  -- Step 3: Check if we can use cached data
-  -- Use cache if:
-  -- a) pre_edit matches the cached key, OR
-  -- b) pre_edit is empty AND cursor position hasn't changed (rapid consecutive calls)
-  local cached_data = cache.get(pre_edit)
-
-  if not cached_data and pre_edit == "" then
-    -- If pre_edit is empty but we're at the same cursor position, use cache
-    local state = cache.get_state()
-    if state.meta then
-      local same_position = (state.meta[1] == cursor_line and state.meta[2] == cursor_col)
-      local cache_age = vim.loop.now() - state.timestamp
-
-      if same_position and cache_age < cache.get_ttl() then
-        utils.debug_log(string.format("Using cache at same position (age=%dms)", cache_age))
-        -- Re-fetch from cache using the original key
-        cached_data = cache.get(state.key)
-      end
-    end
-  end
-
+  local cached_data = lookup_cache(pre_edit, cursor_line, cursor_col)
   if cached_data then
-    local stats = cache.get_stats()
-    local hit_rate = stats.hit_rate
-    utils.debug_log(
-      string.format(
-        "Cache HIT for '%s' (total: %d/%d, %.1f%%)",
-        pre_edit,
-        stats.hits,
-        stats.hits + stats.misses,
-        hit_rate
-      )
-    )
     return cached_data.candidates, cached_data.ranks, cached_data.pre_edit
   end
 
-  -- Step 4: Cache miss - fetch data
   utils.debug_log(string.format("Cache MISS for '%s', fetching...", pre_edit))
-
   local candidates = request("getCompletionResult") or {}
   local ranks_array = request("getRanks") or {}
-
   utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #candidates))
 
-  -- Step 5: Update cache with cursor position
-  cache.set(pre_edit, {
-    candidates = candidates,
-    ranks = ranks_array,
-    pre_edit = pre_edit,
-  }, { cursor_line, cursor_col })
-
+  store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
   return candidates, ranks_array, pre_edit
+end
+
+--- Get completion data from skkeleton without blocking the UI.
+--- Issues the getPreEdit / getCompletionResult / getRanks RPCs via
+--- denops#request_async and invokes `callback` once the data is ready. The
+--- same caching strategy as the synchronous variant is applied.
+--- @param callback fun(candidates: table, ranks_array: table, pre_edit: string)
+function M.get_completion_data_async(callback)
+  local cursor_pos = vim.api.nvim_win_get_cursor(0)
+  local cursor_line = cursor_pos[1]
+  local cursor_col = cursor_pos[2]
+
+  request_async("getPreEdit", function(raw_pre_edit)
+    local pre_edit = normalize_pre_edit(raw_pre_edit)
+
+    local cached_data = lookup_cache(pre_edit, cursor_line, cursor_col)
+    if cached_data then
+      callback(cached_data.candidates, cached_data.ranks, cached_data.pre_edit)
+      return
+    end
+
+    utils.debug_log(string.format("Cache MISS for '%s', fetching (async)...", pre_edit))
+    request_async("getCompletionResult", function(raw_candidates)
+      local candidates = raw_candidates or {}
+      request_async("getRanks", function(raw_ranks)
+        local ranks_array = raw_ranks or {}
+        store_cache(pre_edit, candidates, ranks_array, cursor_line, cursor_col)
+        utils.debug_log(string.format("pre_edit='%s', candidates=%d", pre_edit, #candidates))
+        callback(candidates, ranks_array, pre_edit)
+      end, function()
+        -- getRanks failed: still surface candidates with empty ranks
+        store_cache(pre_edit, candidates, {}, cursor_line, cursor_col)
+        callback(candidates, {}, pre_edit)
+      end)
+    end, function()
+      callback({}, {}, pre_edit)
+    end)
+  end, function()
+    callback({}, {}, "")
+  end)
 end
 
 --- Register completion result with skkeleton for dictionary learning

--- a/tests/test_init.lua
+++ b/tests/test_init.lua
@@ -203,6 +203,8 @@ T["get_completions"]["builds completion items correctly"] = function()
             success({ { "愛", 100 } })
           elseif method == "getPreEdit" then
             success("▽あい")
+          elseif method == "getPrefix" then
+            success("あい")
           end
         end
       end

--- a/tests/test_init.lua
+++ b/tests/test_init.lua
@@ -185,6 +185,7 @@ T["get_completions"]["returns empty when skkeleton is disabled"] = function()
 end
 
 T["get_completions"]["builds completion items correctly"] = function()
+  require("blink-cmp-skkeleton.skkeleton").clear_cache()
   local source = new_source()
   local old_fn = vim.fn
   vim.fn = setmetatable({}, {
@@ -194,14 +195,14 @@ T["get_completions"]["builds completion items correctly"] = function()
           return 1
         end
       end
-      if k == "denops#request" then
-        return function(plugin, method, args)
+      if k == "denops#request_async" then
+        return function(plugin, method, args, success, _failure)
           if method == "getCompletionResult" then
-            return { { "あい", { "愛", "藍;indigo" } } }
+            success({ { "あい", { "愛", "藍;indigo" } } })
           elseif method == "getRanks" then
-            return { { "愛", 100 } }
+            success({ { "愛", 100 } })
           elseif method == "getPreEdit" then
-            return "▽あい"
+            success("▽あい")
           end
         end
       end
@@ -209,10 +210,20 @@ T["get_completions"]["builds completion items correctly"] = function()
     end,
   })
 
+  -- extract_filter_text slices the live buffer line using context.bounds, so
+  -- populate the buffer to exercise the real path (filterText == reading
+  -- without the ▽ marker). "▽あい" is 9 bytes; "あい" starts at byte 4.
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "▽あい" })
+  vim.api.nvim_win_set_cursor(0, { 1, 9 })
+
   local callback_called = false
   local items = nil
 
-  source:get_completions({ cursor = { 1, 9 }, line = "▽あい" }, function(response)
+  source:get_completions({
+    cursor = { 1, 9 },
+    line = "▽あい",
+    bounds = { start_col = 4, length = 6 },
+  }, function(response)
     callback_called = true
     items = response.items
   end)
@@ -226,7 +237,9 @@ T["get_completions"]["builds completion items correctly"] = function()
   expect.equality(items[2].label, "藍")
   expect.no_equality(items[2].documentation, nil)
 
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "" })
   vim.fn = old_fn
+  require("blink-cmp-skkeleton.skkeleton").clear_cache()
 end
 
 -- resolve tests

--- a/tests/test_skkeleton.lua
+++ b/tests/test_skkeleton.lua
@@ -533,4 +533,106 @@ T["cache TTL boundary"]["just before TTL is cache hit"] = function()
   skkeleton.clear_cache()
 end
 
+-- get_completion_data_async tests
+T["get_completion_data_async"] = new_set()
+
+--- Build a vim.fn mock whose denops#request_async resolves each method via the
+--- success callback. `counter` (optional) is incremented per async RPC.
+local function mock_async(old_fn, responses, counter)
+  return setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, _failure)
+          if counter then
+            counter.count = counter.count + 1
+          end
+          success(responses[method])
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+end
+
+T["get_completion_data_async"]["returns completion data"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛", "藍" } } },
+    getRanks = { { "愛", 100 } },
+  })
+
+  local result
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 1)
+  expect.equality(result.candidates[1][1], "あい")
+  expect.equality(result.ranks_array[1][1], "愛")
+  expect.equality(result.pre_edit, "▽あい")
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["returns empty data on failure"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  vim.fn = setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, failure)
+          if method == "getPreEdit" then
+            success("▽あい")
+          else
+            -- getCompletionResult fails
+            failure("boom")
+          end
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+
+  local result
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 0)
+  expect.equality(#result.ranks_array, 0)
+  expect.equality(result.pre_edit, "▽あい")
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["caches result for same pre_edit"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  local counter = { count = 0 }
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = { { "愛", 100 } },
+  }, counter)
+
+  -- First call: cache miss (getPreEdit + getCompletionResult + getRanks)
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 3)
+
+  -- Second call: cache hit (only getPreEdit to check the key)
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 1)
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
 return T

--- a/tests/test_skkeleton.lua
+++ b/tests/test_skkeleton.lua
@@ -538,6 +538,9 @@ T["get_completion_data_async"] = new_set()
 
 --- Build a vim.fn mock whose denops#request_async resolves each method via the
 --- success callback. `counter` (optional) is incremented per async RPC.
+--- When `responses.getPrefix` is omitted it defaults to the getPreEdit value
+--- with the leading ▽ marker stripped (= the henkanFeed), so existing fixtures
+--- keep working with the prefix-anchored async flow.
 local function mock_async(old_fn, responses, counter)
   return setmetatable({}, {
     __index = function(_, k)
@@ -546,7 +549,11 @@ local function mock_async(old_fn, responses, counter)
           if counter then
             counter.count = counter.count + 1
           end
-          success(responses[method])
+          local value = responses[method]
+          if method == "getPrefix" and value == nil then
+            value = (responses.getPreEdit or ""):gsub("^▽", "")
+          end
+          success(value)
         end
       end
       return old_fn[k]
@@ -585,7 +592,9 @@ T["get_completion_data_async"]["returns empty data on failure"] = function()
     __index = function(_, k)
       if k == "denops#request_async" then
         return function(_plugin, method, _args, success, failure)
-          if method == "getPreEdit" then
+          if method == "getPrefix" then
+            success("あい")
+          elseif method == "getPreEdit" then
             success("▽あい")
           else
             -- getCompletionResult fails
@@ -621,15 +630,107 @@ T["get_completion_data_async"]["caches result for same pre_edit"] = function()
     getRanks = { { "愛", 100 } },
   }, counter)
 
-  -- First call: cache miss (getPreEdit + getCompletionResult + getRanks)
+  -- First call: cache miss
+  -- (getPrefix + getPreEdit + getCompletionResult + getRanks)
   counter.count = 0
   skkeleton.get_completion_data_async(function() end)
-  expect.equality(counter.count, 3)
+  expect.equality(counter.count, 4)
 
-  -- Second call: cache hit (only getPreEdit to check the key)
+  -- Second call: cache hit (getPrefix + getPreEdit to check the key)
   counter.count = 0
   skkeleton.get_completion_data_async(function() end)
-  expect.equality(counter.count, 1)
+  expect.equality(counter.count, 2)
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["drops candidates whose midashi does not match the prefix"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  vim.fn = mock_async(old_fn, {
+    getPrefix = "あい",
+    getPreEdit = "▽あい",
+    -- "じぇい" は prefix "あい" に前方一致しないので除去される
+    getCompletionResult = { { "あい", { "愛" } }, { "じぇい", { "J POINTS" } } },
+    getRanks = { { "愛", 100 } },
+  })
+
+  local result
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 1)
+  expect.equality(result.candidates[1][1], "あい")
+  expect.equality(result.pre_edit, "▽あい")
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["returns empty when not in input state"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  local completion_called = false
+  vim.fn = setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, _failure)
+          if method == "getPrefix" then
+            success("")
+          elseif method == "getCompletionResult" then
+            completion_called = true
+            success({})
+          else
+            success(nil)
+          end
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+
+  local result
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 0)
+  expect.equality(result.pre_edit, "")
+  -- empty prefix short-circuits before fetching candidates
+  expect.equality(completion_called, false)
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["bails out and skips fetching when cancelled"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  local counter = { count = 0 }
+  vim.fn = mock_async(old_fn, {
+    getPrefix = "あい",
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = { { "愛", 100 } },
+  }, counter)
+
+  local result
+  counter.count = 0
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end, function()
+    return true
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 0)
+  expect.equality(result.pre_edit, "")
+  -- cancelled before the first RPC: the chain never issues a request
+  expect.equality(counter.count, 0)
 
   vim.fn = old_fn
   skkeleton.clear_cache()

--- a/tests/test_skkeleton.lua
+++ b/tests/test_skkeleton.lua
@@ -8,6 +8,31 @@ local skkeleton = require("blink-cmp-skkeleton.skkeleton")
 
 local T = new_set()
 
+--- Build a vim.fn mock whose denops#request_async resolves each method via the
+--- success callback. `counter` (optional) is incremented per async RPC.
+--- When `responses.getPrefix` is omitted it defaults to the getPreEdit value
+--- with the leading ▽ marker stripped (= the henkanFeed), so existing fixtures
+--- keep working with the prefix-anchored async flow.
+local function mock_async(old_fn, responses, counter)
+  return setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, _failure)
+          if counter then
+            counter.count = counter.count + 1
+          end
+          local value = responses[method]
+          if method == "getPrefix" and value == nil then
+            value = (responses.getPreEdit or ""):gsub("^▽", "")
+          end
+          success(value)
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+end
+
 -- is_enabled tests
 T["is_enabled"] = new_set()
 
@@ -68,193 +93,6 @@ T["is_enabled"]["returns false on error"] = function()
   vim.fn = old_fn
 end
 
--- get_completion_data tests
-T["get_completion_data"] = new_set()
-
-T["get_completion_data"]["returns completion data"] = function()
-  local old_fn = vim.fn
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          if method == "getCompletionResult" then
-            return { { "あい", { "愛", "藍" } } }
-          elseif method == "getRanks" then
-            return { { "愛", 100 } }
-          elseif method == "getPreEdit" then
-            return "▽あい"
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  local candidates, ranks_array, pre_edit = skkeleton.get_completion_data()
-
-  expect.equality(#candidates, 1)
-  expect.equality(candidates[1][1], "あい")
-  expect.equality(#ranks_array, 1)
-  expect.equality(ranks_array[1][1], "愛")
-  expect.equality(pre_edit, "▽あい")
-
-  vim.fn = old_fn
-end
-
-T["get_completion_data"]["returns empty data on error"] = function()
-  skkeleton.clear_cache()
-  local old_fn = vim.fn
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function()
-          error("test error")
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  local candidates, ranks_array, pre_edit = skkeleton.get_completion_data()
-
-  expect.equality(type(candidates), "table")
-  expect.equality(#candidates, 0)
-  expect.equality(type(ranks_array), "table")
-  expect.equality(#ranks_array, 0)
-  expect.equality(pre_edit, "")
-
-  vim.fn = old_fn
-end
-
--- Cache tests
-T["get_completion_data cache"] = new_set()
-
-T["get_completion_data cache"]["caches result for same pre_edit"] = function()
-  skkeleton.clear_cache()
-  local old_fn = vim.fn
-  local denops_call_count = 0
-
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          denops_call_count = denops_call_count + 1
-          if method == "getCompletionResult" then
-            return { { "あい", { "愛", "藍" } } }
-          elseif method == "getRanks" then
-            return { { "愛", 100 } }
-          elseif method == "getPreEdit" then
-            return "▽あい"
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  -- First call: cache miss (3 RPC calls)
-  denops_call_count = 0
-  local c1, r1, p1 = skkeleton.get_completion_data()
-  local first_call_count = denops_call_count
-  expect.equality(first_call_count, 3) -- getPreEdit + getCompletionResult + getRanks
-
-  -- Second call: cache hit (only 1 RPC call - getPreEdit to check key)
-  denops_call_count = 0
-  local c2, r2, p2 = skkeleton.get_completion_data()
-  local second_call_count = denops_call_count
-  expect.equality(second_call_count, 1) -- only getPreEdit
-
-  -- Data should be same
-  expect.equality(#c1, #c2)
-  expect.equality(p1, p2)
-
-  vim.fn = old_fn
-  skkeleton.clear_cache()
-end
-
-T["get_completion_data cache"]["invalidates cache on pre_edit change"] = function()
-  local old_fn = vim.fn
-  local pre_edit_value = "▽あい"
-
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          if method == "getPreEdit" then
-            return pre_edit_value
-          elseif method == "getCompletionResult" then
-            return { { pre_edit_value:sub(4), { "test" } } }
-          elseif method == "getRanks" then
-            return {}
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  -- First call
-  local c1, r1, p1 = skkeleton.get_completion_data()
-  expect.equality(p1, "▽あい")
-
-  -- Change pre_edit
-  pre_edit_value = "▽あいう"
-
-  -- Second call: cache miss (different pre_edit)
-  local c2, r2, p2 = skkeleton.get_completion_data()
-  expect.equality(p2, "▽あいう")
-  expect.no_equality(p1, p2)
-
-  vim.fn = old_fn
-  skkeleton.clear_cache()
-end
-
-T["get_completion_data cache"]["clears cache after register_completion"] = function()
-  local old_fn = vim.fn
-  local denops_call_count = 0
-
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          if method ~= "completeCallback" then
-            denops_call_count = denops_call_count + 1
-          end
-          if method == "getPreEdit" then
-            return "▽あい"
-          elseif method == "getCompletionResult" then
-            return { { "あい", { "愛" } } }
-          elseif method == "getRanks" then
-            return { { "愛", 100 } }
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  -- Populate cache
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 3)
-
-  -- Verify cache works
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 1) -- cache hit
-
-  -- Register completion (should clear cache)
-  skkeleton.register_completion("あい", "愛", "okurinasi")
-
-  -- Next call should be cache miss
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 3) -- cache was cleared
-
-  vim.fn = old_fn
-  skkeleton.clear_cache()
-end
-
 -- register_completion tests
 T["register_completion"] = new_set()
 
@@ -288,278 +126,8 @@ T["register_completion"]["calls denops request"] = function()
   skkeleton.clear_cache()
 end
 
--- Cache configuration tests
-T["cache configuration"] = new_set()
-
-T["cache configuration"]["uses custom TTL from vim.g"] = function()
-  local old_fn = vim.fn
-  local old_g = vim.g.blink_cmp_skkeleton_cache_ttl
-  local old_loop = vim.loop
-
-  -- Set custom TTL to 50ms
-  vim.g.blink_cmp_skkeleton_cache_ttl = 50
-
-  local current_time = 0
-  vim.loop = {
-    now = function()
-      return current_time
-    end,
-  }
-
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          if method == "getPreEdit" then
-            return "▽あい"
-          elseif method == "getCompletionResult" then
-            return { { "あい", { "愛" } } }
-          elseif method == "getRanks" then
-            return {}
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  -- First call at t=0
-  current_time = 0
-  skkeleton.clear_cache()
-  skkeleton.get_completion_data()
-
-  -- After 40ms (within 50ms TTL) - should be cache hit
-  current_time = 40
-  local c1, r1, p1 = skkeleton.get_completion_data()
-  expect.equality(p1, "▽あい") -- Should use cache
-
-  -- After 60ms (beyond 50ms TTL) - should be cache miss
-  current_time = 60
-  local c2, r2, p2 = skkeleton.get_completion_data()
-  expect.equality(p2, "▽あい") -- Should refetch
-
-  vim.fn = old_fn
-  vim.loop = old_loop
-  vim.g.blink_cmp_skkeleton_cache_ttl = old_g
-  skkeleton.clear_cache()
-end
-
--- Cache metrics tests
-T["cache metrics"] = new_set()
-
-T["cache metrics"]["tracks hit and miss counts"] = function()
-  local old_fn = vim.fn
-
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          if method == "getPreEdit" then
-            return "▽あい"
-          elseif method == "getCompletionResult" then
-            return { { "あい", { "愛" } } }
-          elseif method == "getRanks" then
-            return {}
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  skkeleton.clear_cache()
-  local stats = skkeleton.get_cache_stats()
-  local initial_hits = stats.hits
-  local initial_misses = stats.misses
-
-  -- First call: miss
-  skkeleton.get_completion_data()
-  stats = skkeleton.get_cache_stats()
-  expect.equality(stats.misses, initial_misses + 1)
-
-  -- Second call: hit
-  skkeleton.get_completion_data()
-  stats = skkeleton.get_cache_stats()
-  expect.equality(stats.hits, initial_hits + 1)
-
-  vim.fn = old_fn
-  skkeleton.clear_cache()
-end
-
-T["cache metrics"]["calculates hit rate correctly"] = function()
-  local old_fn = vim.fn
-
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          if method == "getPreEdit" then
-            return "▽あい"
-          elseif method == "getCompletionResult" then
-            return { { "あい", { "愛" } } }
-          elseif method == "getRanks" then
-            return {}
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  skkeleton.clear_cache()
-
-  -- 1 miss + 3 hits = 75% hit rate
-  skkeleton.get_completion_data() -- miss
-  skkeleton.get_completion_data() -- hit
-  skkeleton.get_completion_data() -- hit
-  skkeleton.get_completion_data() -- hit
-
-  local stats = skkeleton.get_cache_stats()
-  expect.equality(stats.hit_rate >= 74 and stats.hit_rate <= 76, true) -- Allow for floating point
-
-  vim.fn = old_fn
-  skkeleton.clear_cache()
-end
-
--- TTL boundary tests (uses default 100ms TTL)
-T["cache TTL boundary"] = new_set()
-
-T["cache TTL boundary"]["invalidates at exact TTL boundary"] = function()
-  local old_fn = vim.fn
-  local old_loop = vim.loop
-
-  -- Uses default TTL of 100ms (set at module load time)
-  local current_time = 0
-  vim.loop = {
-    now = function()
-      return current_time
-    end,
-  }
-
-  local denops_call_count = 0
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          denops_call_count = denops_call_count + 1
-          if method == "getPreEdit" then
-            return "▽あい"
-          elseif method == "getCompletionResult" then
-            return { { "あい", { "愛" } } }
-          elseif method == "getRanks" then
-            return {}
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  -- First call at t=0 (cache miss)
-  current_time = 0
-  skkeleton.clear_cache()
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 3) -- miss: getPreEdit + getCompletionResult + getRanks
-
-  -- At t=99 (just before 100ms TTL) - should be cache hit
-  current_time = 99
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 1) -- hit: only getPreEdit
-
-  -- At t=100 (exactly at 100ms TTL) - should be cache miss
-  current_time = 100
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 3) -- miss: full fetch
-
-  vim.fn = old_fn
-  vim.loop = old_loop
-  skkeleton.clear_cache()
-end
-
-T["cache TTL boundary"]["just before TTL is cache hit"] = function()
-  local old_fn = vim.fn
-  local old_loop = vim.loop
-
-  local current_time = 0
-  vim.loop = {
-    now = function()
-      return current_time
-    end,
-  }
-
-  local denops_call_count = 0
-  vim.fn = setmetatable({}, {
-    __index = function(t, k)
-      if k == "denops#request" then
-        return function(plugin, method, args)
-          denops_call_count = denops_call_count + 1
-          if method == "getPreEdit" then
-            return "▽あい"
-          elseif method == "getCompletionResult" then
-            return { { "あい", { "愛" } } }
-          elseif method == "getRanks" then
-            return {}
-          end
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-
-  -- First call at t=0 (cache miss)
-  current_time = 0
-  skkeleton.clear_cache()
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 3) -- miss
-
-  -- At t=50 (half of 100ms TTL) - should be cache hit
-  current_time = 50
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 1) -- hit
-
-  -- At t=99 (1ms before TTL) - should still be cache hit
-  current_time = 99
-  denops_call_count = 0
-  skkeleton.get_completion_data()
-  expect.equality(denops_call_count, 1) -- hit
-
-  vim.fn = old_fn
-  vim.loop = old_loop
-  skkeleton.clear_cache()
-end
-
 -- get_completion_data_async tests
 T["get_completion_data_async"] = new_set()
-
---- Build a vim.fn mock whose denops#request_async resolves each method via the
---- success callback. `counter` (optional) is incremented per async RPC.
---- When `responses.getPrefix` is omitted it defaults to the getPreEdit value
---- with the leading ▽ marker stripped (= the henkanFeed), so existing fixtures
---- keep working with the prefix-anchored async flow.
-local function mock_async(old_fn, responses, counter)
-  return setmetatable({}, {
-    __index = function(_, k)
-      if k == "denops#request_async" then
-        return function(_plugin, method, _args, success, _failure)
-          if counter then
-            counter.count = counter.count + 1
-          end
-          local value = responses[method]
-          if method == "getPrefix" and value == nil then
-            value = (responses.getPreEdit or ""):gsub("^▽", "")
-          end
-          success(value)
-        end
-      end
-      return old_fn[k]
-    end,
-  })
-end
 
 T["get_completion_data_async"]["returns completion data"] = function()
   skkeleton.clear_cache()
@@ -640,6 +208,89 @@ T["get_completion_data_async"]["caches result for same pre_edit"] = function()
   counter.count = 0
   skkeleton.get_completion_data_async(function() end)
   expect.equality(counter.count, 2)
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["invalidates cache on pre_edit change"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  local pre_edit_value = "▽あい"
+
+  vim.fn = setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, _failure)
+          if method == "getPrefix" then
+            success((pre_edit_value:gsub("^▽", "")))
+          elseif method == "getPreEdit" then
+            success(pre_edit_value)
+          elseif method == "getCompletionResult" then
+            success({ { pre_edit_value:sub(4), { "test" } } })
+          elseif method == "getRanks" then
+            success({})
+          else
+            success(nil)
+          end
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+
+  -- First call
+  local p1
+  skkeleton.get_completion_data_async(function(_candidates, _ranks_array, pre_edit)
+    p1 = pre_edit
+  end)
+  expect.equality(p1, "▽あい")
+
+  -- Change pre_edit
+  pre_edit_value = "▽あいう"
+
+  -- Second call: cache miss (different pre_edit)
+  local p2
+  skkeleton.get_completion_data_async(function(_candidates, _ranks_array, pre_edit)
+    p2 = pre_edit
+  end)
+  expect.equality(p2, "▽あいう")
+  expect.no_equality(p1, p2)
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["clears cache after register_completion"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  local counter = { count = 0 }
+  -- register_completion issues completeCallback via the synchronous denops#request,
+  -- which this mock leaves to old_fn (pcall-guarded, so it is a harmless no-op in
+  -- tests) and does not count -- only async RPCs increment the counter.
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = { { "愛", 100 } },
+  }, counter)
+
+  -- Populate cache
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 5)
+
+  -- Verify cache works
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 2) -- cache hit
+
+  -- Register completion (should clear cache)
+  skkeleton.register_completion("あい", "愛", "okurinasi")
+
+  -- Next call should be cache miss
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 5) -- cache was cleared
 
   vim.fn = old_fn
   skkeleton.clear_cache()
@@ -777,6 +428,194 @@ T["get_completion_data_async"]["bails out and skips fetching when cancelled"] = 
   expect.equality(counter.count, 0)
 
   vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+-- Cache configuration tests
+T["cache configuration"] = new_set()
+
+T["cache configuration"]["returns data with custom TTL from vim.g"] = function()
+  local old_fn = vim.fn
+  local old_g = vim.g.blink_cmp_skkeleton_cache_ttl
+  local old_loop = vim.loop
+
+  vim.g.blink_cmp_skkeleton_cache_ttl = 50
+
+  local current_time = 0
+  vim.loop = {
+    now = function()
+      return current_time
+    end,
+  }
+
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = {},
+  })
+
+  local function fetch()
+    local pre_edit
+    skkeleton.get_completion_data_async(function(_candidates, _ranks_array, p)
+      pre_edit = p
+    end)
+    return pre_edit
+  end
+
+  current_time = 0
+  skkeleton.clear_cache()
+  expect.equality(fetch(), "▽あい")
+
+  current_time = 40
+  expect.equality(fetch(), "▽あい")
+
+  current_time = 60
+  expect.equality(fetch(), "▽あい")
+
+  vim.fn = old_fn
+  vim.loop = old_loop
+  vim.g.blink_cmp_skkeleton_cache_ttl = old_g
+  skkeleton.clear_cache()
+end
+
+-- Cache metrics tests
+T["cache metrics"] = new_set()
+
+T["cache metrics"]["tracks hit and miss counts"] = function()
+  local old_fn = vim.fn
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = {},
+  })
+
+  skkeleton.clear_cache()
+  local stats = skkeleton.get_cache_stats()
+  local initial_hits = stats.hits
+  local initial_misses = stats.misses
+
+  -- First call: miss
+  skkeleton.get_completion_data_async(function() end)
+  stats = skkeleton.get_cache_stats()
+  expect.equality(stats.misses, initial_misses + 1)
+
+  -- Second call: hit
+  skkeleton.get_completion_data_async(function() end)
+  stats = skkeleton.get_cache_stats()
+  expect.equality(stats.hits, initial_hits + 1)
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["cache metrics"]["calculates hit rate correctly"] = function()
+  local old_fn = vim.fn
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = {},
+  })
+
+  skkeleton.clear_cache()
+
+  -- 1 miss + 3 hits = 75% hit rate
+  skkeleton.get_completion_data_async(function() end) -- miss
+  skkeleton.get_completion_data_async(function() end) -- hit
+  skkeleton.get_completion_data_async(function() end) -- hit
+  skkeleton.get_completion_data_async(function() end) -- hit
+
+  local stats = skkeleton.get_cache_stats()
+  expect.equality(stats.hit_rate >= 74 and stats.hit_rate <= 76, true) -- Allow for floating point
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+-- TTL boundary tests (uses default 100ms TTL)
+T["cache TTL boundary"] = new_set()
+
+T["cache TTL boundary"]["invalidates at exact TTL boundary"] = function()
+  local old_fn = vim.fn
+  local old_loop = vim.loop
+
+  -- Uses default TTL of 100ms (set at module load time)
+  local current_time = 0
+  vim.loop = {
+    now = function()
+      return current_time
+    end,
+  }
+
+  local counter = { count = 0 }
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = {},
+  }, counter)
+
+  -- First call at t=0 (cache miss)
+  current_time = 0
+  skkeleton.clear_cache()
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 5) -- miss: full fetch + prefix re-check
+
+  -- At t=99 (just before 100ms TTL) - should be cache hit
+  current_time = 99
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 2) -- hit: getPrefix + getPreEdit
+
+  -- At t=100 (exactly at 100ms TTL) - should be cache miss
+  current_time = 100
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 5) -- miss: full fetch
+
+  vim.fn = old_fn
+  vim.loop = old_loop
+  skkeleton.clear_cache()
+end
+
+T["cache TTL boundary"]["just before TTL is cache hit"] = function()
+  local old_fn = vim.fn
+  local old_loop = vim.loop
+
+  local current_time = 0
+  vim.loop = {
+    now = function()
+      return current_time
+    end,
+  }
+
+  local counter = { count = 0 }
+  vim.fn = mock_async(old_fn, {
+    getPreEdit = "▽あい",
+    getCompletionResult = { { "あい", { "愛" } } },
+    getRanks = {},
+  }, counter)
+
+  -- First call at t=0 (cache miss)
+  current_time = 0
+  skkeleton.clear_cache()
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 5) -- miss
+
+  -- At t=50 (half of 100ms TTL) - should be cache hit
+  current_time = 50
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 2) -- hit
+
+  -- At t=99 (1ms before TTL) - should still be cache hit
+  current_time = 99
+  counter.count = 0
+  skkeleton.get_completion_data_async(function() end)
+  expect.equality(counter.count, 2) -- hit
+
+  vim.fn = old_fn
+  vim.loop = old_loop
   skkeleton.clear_cache()
 end
 

--- a/tests/test_skkeleton.lua
+++ b/tests/test_skkeleton.lua
@@ -631,10 +631,10 @@ T["get_completion_data_async"]["caches result for same pre_edit"] = function()
   }, counter)
 
   -- First call: cache miss
-  -- (getPrefix + getPreEdit + getCompletionResult + getRanks)
+  -- (getPrefix + getPreEdit + getCompletionResult + getRanks + getPrefix re-check)
   counter.count = 0
   skkeleton.get_completion_data_async(function() end)
-  expect.equality(counter.count, 4)
+  expect.equality(counter.count, 5)
 
   -- Second call: cache hit (getPrefix + getPreEdit to check the key)
   counter.count = 0
@@ -665,6 +665,50 @@ T["get_completion_data_async"]["drops candidates whose midashi does not match th
   expect.equality(#result.candidates, 1)
   expect.equality(result.candidates[1][1], "あい")
   expect.equality(result.pre_edit, "▽あい")
+
+  vim.fn = old_fn
+  skkeleton.clear_cache()
+end
+
+T["get_completion_data_async"]["discards result when prefix changes mid-fetch"] = function()
+  skkeleton.clear_cache()
+  local old_fn = vim.fn
+  -- getPrefix is read twice: once up front, once after candidates/ranks. Return
+  -- a different henkanFeed the second time to simulate a keystroke landing
+  -- mid-fetch. The reading/candidates are then from inconsistent states and the
+  -- whole result must be dropped.
+  local prefix_calls = 0
+  vim.fn = setmetatable({}, {
+    __index = function(_, k)
+      if k == "denops#request_async" then
+        return function(_plugin, method, _args, success, _failure)
+          if method == "getPrefix" then
+            prefix_calls = prefix_calls + 1
+            success(prefix_calls == 1 and "あい" or "あいう")
+          elseif method == "getPreEdit" then
+            success("▽あい")
+          elseif method == "getCompletionResult" then
+            success({ { "あい", { "愛" } } })
+          elseif method == "getRanks" then
+            success({ { "愛", 100 } })
+          else
+            success(nil)
+          end
+        end
+      end
+      return old_fn[k]
+    end,
+  })
+
+  local result
+  skkeleton.get_completion_data_async(function(candidates, ranks_array, pre_edit)
+    result = { candidates = candidates, ranks_array = ranks_array, pre_edit = pre_edit }
+  end)
+
+  expect.no_equality(result, nil)
+  expect.equality(#result.candidates, 0)
+  expect.equality(result.pre_edit, "")
+  expect.equality(prefix_calls, 2)
 
   vim.fn = old_fn
   skkeleton.clear_cache()


### PR DESCRIPTION
`get_completions` は同期版の `denops#request` を利用しており、これは skkeleton が応答するまで Neovim のメインループ（つまり UI 操作）を止めます。`sources = { "skk_server" }` の場合はここに skkserv との往復が含まれるため、遅いサーバー（例えば辞書に無い読みを Google 日本語入力にフォールバックするもの）では補完を発火するキーストロークの度に Neovim がフリーズします。

## 変更内容

補完の取得を非同期化しました。`denops#request_async` を使う `get_completion_data_async` を追加しました。非同期にすると RPC が一続きで無くなり、往復の合間のキー入力で読みと候補がずれる余地があります。これを防ぐガードを併せて入れています。

- 遅れて届いた古い応答は破棄し、新しいリクエストの結果を上書きしないようにします。
- 確定している読み（`getPrefix`）で始まらない候補を捨てます。
- リクエストの前後で `getPrefix` を読み直し、途中で `henkanFeed` が変わっていれば結果一式を破棄します。

## 関連

この修正により、skkeleton への重なり合う RPC を発行するようになったため、skkeleton からのレスポンスの取り違いが起こるバグに遭遇しました。これについては別途 PR（vim-skk/skkeleton#248）しています。こちらがマージされないと、今回の修正だけではバグにより skkserv 利用時に上手く動作しません（マージされるまでこちらはドラフトにしておきます）。
