### PR TITLE
skkeleton の補完バックエンドとして blink.cmp を登録する

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ Native [blink.cmp](https://github.com/saghen/blink.cmp) source for [skkeleton](h
 
 ## ⚙️ Configuration
 
+### Confirming a candidate with `<CR>`
+
+skkeleton's `eggLikeNewline` confirms the highlighted candidate with `<CR>` instead of inserting a newline. skkeleton does not guess which completion engine is on screen, so tell it to use blink.cmp:
+
+```lua
+vim.fn["skkeleton#config"]({
+  eggLikeNewline = true,
+  completionBackend = "blink.cmp",
+})
+```
+
+This plugin registers the `blink.cmp` backend with skkeleton automatically, so only the `completionBackend` line above is up to you. Without it skkeleton talks to the built-in popup menu and `<CR>` will not confirm a blink.cmp candidate.
+
+> **Note**: Requires a skkeleton with `skkeleton#register_completion_backend()`. On older versions the registration is skipped silently and `completionBackend` does not exist.
+
 ### Cache Settings
 
 The plugin uses intelligent caching to reduce redundant denops RPC calls:
@@ -236,6 +251,12 @@ The plugin automatically detects the henkan type:
 - Otherwise → okurinasi
 
 This information is passed to skkeleton's `completeCallback` for proper dictionary registration.
+
+### Completion Backend Registration
+
+`backend.register()` runs from `skkeleton-enable-pre`, the hook skkeleton documents for setting itself up. skkeleton only consults the backend while a completion menu is open, so registering there is early enough.
+
+This does mean the plugin has to be loaded by then. If your plugin manager only loads it when blink.cmp first asks for its source, skkeleton reports `unknown completionBackend` and stays on `native`. Loading it together with blink.cmp — as in the installation example above — avoids that.
 
 </details>
 

--- a/lua/blink-cmp-skkeleton/backend.lua
+++ b/lua/blink-cmp-skkeleton/backend.lua
@@ -1,0 +1,68 @@
+--- Completion backend registration for skkeleton
+---
+--- skkeleton needs to know which completion engine is currently showing
+--- candidates so that `eggLikeNewline` can confirm the selected item with
+--- `<CR>`. Since skkeleton no longer auto-detects the engine, it exposes
+--- `skkeleton#register_completion_backend()` and lets the user pick one by
+--- name via `completionBackend`. We register the blink.cmp definition here so
+--- users only have to write:
+---
+---     call skkeleton#config(#{ completionBackend: 'blink.cmp' })
+---
+--- Registering is a no-op for users who do not select this backend, and it is
+--- silently skipped when the installed skkeleton predates the API.
+--- @module blink-cmp-skkeleton.backend
+
+local utils = require("blink-cmp-skkeleton.utils")
+
+local M = {}
+
+--- Name to be given to |skkeleton-config-completionBackend|
+M.name = "blink.cmp"
+
+--- Report the state of blink.cmp's completion menu to skkeleton.
+--- `selected` follows skkeleton's convention: a negative value means no
+--- candidate is selected.
+--- @return { pum_visible: boolean, selected: integer }
+function M.complete_info()
+  local ok, blink_cmp = pcall(require, "blink.cmp")
+  if not ok or not blink_cmp.is_menu_visible() then
+    return { pum_visible = false, selected = -1 }
+  end
+  return {
+    pum_visible = true,
+    selected = blink_cmp.get_selected_item() ~= nil and 1 or -1,
+  }
+end
+
+--- Register the blink.cmp backend with skkeleton, unconditionally.
+--- Calling the function is what pulls in skkeleton's autoload script, so this
+--- works without checking `exists()` first.
+--- @return boolean registered false when skkeleton lacks the API
+function M.register()
+  local ok, err = pcall(vim.fn["skkeleton#register_completion_backend"], M.name, {
+    complete_info = M.complete_info,
+    confirm_key = "<Cmd>lua require('blink.cmp').select_and_accept()",
+  })
+  if not ok then
+    utils.debug_log("skkeleton#register_completion_backend() failed, skipped: " .. tostring(err))
+    return false
+  end
+  utils.debug_log("registered completion backend: " .. M.name)
+  return true
+end
+
+--- Register the backend once skkeleton is about to be enabled.
+--- This is the point skkeleton documents for setting itself up, and it is early
+--- enough: skkeleton only consults the backend while a completion menu is open.
+function M.setup()
+  vim.api.nvim_create_autocmd("User", {
+    group = vim.api.nvim_create_augroup("blink-cmp-skkeleton-backend", { clear = true }),
+    pattern = "skkeleton-enable-pre",
+    once = true,
+    callback = M.register,
+    desc = "Register blink.cmp as a skkeleton completion backend",
+  })
+end
+
+return M

--- a/plugin/blink-cmp-skkeleton.lua
+++ b/plugin/blink-cmp-skkeleton.lua
@@ -1,6 +1,12 @@
 --- Auto-setup autocmds for blink.cmp integration with skkeleton
 --- Set vim.g.blink_cmp_skkeleton_auto_setup = false to disable
 
+-- Teach skkeleton how to talk to blink.cmp. This only makes the backend
+-- selectable; it takes effect once the user sets
+--   call skkeleton#config(#{ completionBackend: 'blink.cmp' })
+-- so it is registered even when auto-setup is disabled.
+require("blink-cmp-skkeleton.backend").setup()
+
 -- Check if user wants to disable auto-setup
 if vim.g.blink_cmp_skkeleton_auto_setup == false then
   return

--- a/tests/test_backend.lua
+++ b/tests/test_backend.lua
@@ -1,0 +1,212 @@
+--- Tests for blink-cmp-skkeleton.backend module
+--- Run with: just test
+
+local new_set = MiniTest.new_set
+local expect = MiniTest.expect
+
+local backend = require("blink-cmp-skkeleton.backend")
+
+--- Replace `require("blink.cmp")` with a stub for the duration of `fn`
+--- @param stub table|nil nil to simulate blink.cmp being unavailable
+--- @param fn fun()
+local function with_blink_cmp(stub, fn)
+  local saved = package.loaded["blink.cmp"]
+  local saved_loader = package.preload["blink.cmp"]
+  package.loaded["blink.cmp"] = stub
+  if stub == nil then
+    -- Stop require() from finding the real module on the runtimepath
+    package.preload["blink.cmp"] = function()
+      error("blink.cmp is not installed")
+    end
+  end
+  local ok, err = pcall(fn)
+  package.loaded["blink.cmp"] = saved
+  package.preload["blink.cmp"] = saved_loader
+  if not ok then
+    error(err)
+  end
+end
+
+local T = new_set()
+
+T["complete_info"] = new_set()
+
+T["complete_info"]["reports not visible when blink.cmp is unavailable"] = function()
+  with_blink_cmp(nil, function()
+    local info = backend.complete_info()
+    expect.equality(info.pum_visible, false)
+    expect.equality(info.selected, -1)
+  end)
+end
+
+T["complete_info"]["reports not visible when the menu is closed"] = function()
+  with_blink_cmp({
+    is_menu_visible = function()
+      return false
+    end,
+    get_selected_item = function()
+      return nil
+    end,
+  }, function()
+    local info = backend.complete_info()
+    expect.equality(info.pum_visible, false)
+    expect.equality(info.selected, -1)
+  end)
+end
+
+T["complete_info"]["reports no selection while the menu is open"] = function()
+  with_blink_cmp({
+    is_menu_visible = function()
+      return true
+    end,
+    get_selected_item = function()
+      return nil
+    end,
+  }, function()
+    local info = backend.complete_info()
+    expect.equality(info.pum_visible, true)
+    expect.equality(info.selected, -1)
+  end)
+end
+
+T["complete_info"]["reports a selection while the menu is open"] = function()
+  with_blink_cmp({
+    is_menu_visible = function()
+      return true
+    end,
+    get_selected_item = function()
+      return { label = "愛" }
+    end,
+  }, function()
+    local info = backend.complete_info()
+    expect.equality(info.pum_visible, true)
+    expect.equality(info.selected, 1)
+  end)
+end
+
+--- Replace `vim.fn` with a stub that pretends skkeleton's API does (not) exist.
+--- Autoload functions cannot be defined outside their own script (E746), so
+--- the registration call itself has to be intercepted on the Lua side. When
+--- `available` is false the key is simply absent, so the call falls through to
+--- the real `vim.fn` and raises E117 just like an uninstalled skkeleton would.
+--- @param available boolean
+--- @param fn fun(captured: table)
+local function with_skkeleton_api(available, fn)
+  local api = "skkeleton#register_completion_backend"
+  local saved = vim.fn
+  local captured = {}
+  local stub = {}
+  captured.count = 0
+  if available then
+    stub[api] = function(name, definition)
+      captured.count = captured.count + 1
+      captured.name = name
+      captured.definition = definition
+    end
+  end
+  vim.fn = setmetatable(stub, { __index = saved })
+  local ok, err = pcall(fn, captured)
+  vim.fn = saved
+  if not ok then
+    error(err)
+  end
+end
+
+T["register"] = new_set()
+
+T["register"]["is skipped when skkeleton lacks the API"] = function()
+  with_skkeleton_api(false, function(captured)
+    expect.equality(backend.register(), false)
+    expect.equality(captured.name, nil)
+  end)
+end
+
+T["register"]["passes the backend definition to skkeleton"] = function()
+  with_skkeleton_api(true, function(captured)
+    with_blink_cmp({
+      is_menu_visible = function()
+        return true
+      end,
+      get_selected_item = function()
+        return { label = "藍" }
+      end,
+    }, function()
+      expect.equality(backend.register(), true)
+      expect.equality(captured.name, "blink.cmp")
+      expect.equality(captured.definition.confirm_key, "<Cmd>lua require('blink.cmp').select_and_accept()")
+      local info = captured.definition.complete_info()
+      expect.equality(info.pum_visible, true)
+      expect.equality(info.selected, 1)
+    end)
+  end)
+end
+
+T["setup"] = new_set({
+  hooks = {
+    post_case = function()
+      pcall(vim.api.nvim_del_augroup_by_name, "blink-cmp-skkeleton-backend")
+    end,
+  },
+})
+
+T["setup"]["registers once from skkeleton-enable-pre"] = function()
+  with_skkeleton_api(true, function(captured)
+    backend.setup()
+    -- Nothing happens until skkeleton is about to be enabled
+    expect.equality(captured.count, 0)
+    vim.api.nvim_exec_autocmds("User", { pattern = "skkeleton-enable-pre" })
+    expect.equality(captured.count, 1)
+    expect.equality(captured.name, "blink.cmp")
+    -- The autocmd is `once`, so a second enable does not register again
+    vim.api.nvim_exec_autocmds("User", { pattern = "skkeleton-enable-pre" })
+    expect.equality(captured.count, 1)
+  end)
+end
+
+T["setup"]["does not pile up autocmds when called twice"] = function()
+  with_skkeleton_api(true, function(captured)
+    backend.setup()
+    backend.setup()
+    vim.api.nvim_exec_autocmds("User", { pattern = "skkeleton-enable-pre" })
+    expect.equality(captured.count, 1)
+  end)
+end
+
+T["register"]["hands skkeleton a definition Vim script can call"] = function()
+  -- skkeleton stores `complete_info` in a Vim script dictionary and calls it on
+  -- every key press, so the Lua function has to survive the conversion into a
+  -- |Funcref|. Use a plain global function since autoload names are rejected
+  -- outside their script (E746).
+  vim.cmd([[
+    function! g:BlinkCmpSkkeletonTestRegister(name, backend) abort
+      let g:blink_cmp_skkeleton_test_backend = #{
+      \   is_func: type(a:backend.complete_info) == v:t_func,
+      \   info: a:backend.complete_info(),
+      \ }
+    endfunction
+  ]])
+
+  with_blink_cmp({
+    is_menu_visible = function()
+      return true
+    end,
+    get_selected_item = function()
+      return { label = "藍" }
+    end,
+  }, function()
+    vim.fn.BlinkCmpSkkeletonTestRegister(backend.name, {
+      complete_info = backend.complete_info,
+      confirm_key = "<Cmd>lua require('blink.cmp').select_and_accept()",
+    })
+  end)
+
+  local got = vim.g.blink_cmp_skkeleton_test_backend
+  expect.equality(got.is_func, 1)
+  expect.equality(got.info.pum_visible, true)
+  expect.equality(got.info.selected, 1)
+
+  vim.cmd("delfunction g:BlinkCmpSkkeletonTestRegister")
+  vim.g.blink_cmp_skkeleton_test_backend = nil
+end
+
+return T


### PR DESCRIPTION
## 問題

skkeleton の `eggLikeNewline` を有効にしても、blink.cmp の補完中に `<CR>` で候補を確定できません。skkeleton が表示中の補完エンジンを pum.vim / nvim-cmp / native の 3 種でしか判定しておらず、blink.cmp が native と誤判定されるためです。

## 修正

skkeleton 本体が補完エンジン連携を登録制に変えたので（vim-skk/skkeleton#249）、blink.cmp 用の定義をこちらから登録します。skkeleton が必要とするのは以下の 2 つだけです。

- `complete_info()`: `blink.cmp` の `is_menu_visible()` と `get_selected_item()` から補完の表示状態を返します。
- `confirm_key`: `<Cmd>lua require('blink.cmp').select_and_accept()`

ユーザー側で必要なのは、どのバックエンドを使うかを選ぶ設定だけです。

```lua
vim.fn["skkeleton#config"]({
  eggLikeNewline = true,
  completionBackend = "blink.cmp",
})
```

登録は skkeleton が設定用に案内している `skkeleton-enable-pre` で行います。skkeleton がバックエンドを参照するのは補完メニューが出ている間だけなので、このタイミングで間に合います。

## 既存ユーザーへの影響

ありません。登録するだけなので、`completionBackend` を選ぶまで挙動は変わりません。`skkeleton#register_completion_backend()` を持たない skkeleton では黙ってスキップします。

## 関連

skkeleton 本体側の PR（vim-skk/skkeleton#253）が前提になります。API が無ければ登録をスキップするだけなので先にマージされても既存ユーザーの環境は壊れませんが、本体の API はまだレビュー前で変わる可能性があります。その場合こちらも追随が必要になるため、本体がマージされるまで Draft にしておきます。
